### PR TITLE
ask about ability to publish name and about CoC

### DIFF
--- a/.github/ISSUE_TEMPLATE/unconference-contribution.md
+++ b/.github/ISSUE_TEMPLATE/unconference-contribution.md
@@ -29,4 +29,8 @@ assignees: ''
 - [ ] October 18
 - [ ] October 19
 
+### By submitting a contribution you agree that
+- [ ] Your name and abstract of the contribution will be published in our program
+- [ ] Your contribution respects the [Code of Conduct](https://nordic-rse.org/about/code-of-conduct)
+
 ### Give a short description of your contribution:


### PR DESCRIPTION
instead of mentioning it at the bottom of the conference webpage under layers of text